### PR TITLE
removed dump.h include

### DIFF
--- a/Source/LuaBridge/LuaBridge.h
+++ b/Source/LuaBridge/LuaBridge.h
@@ -46,8 +46,6 @@
 namespace luabridge
 {
 
-#include "detail/dump.h"
-
 // Forward declaration
 //
 template <class T>


### PR DESCRIPTION
the include causes multiply defined symbols linker errors on at least clang and VC11
