### PR TITLE
Remove deprecation warning for GNU G++ (ext/hash_map -> std::unordered_map)

### DIFF
--- a/Source/LuaBridge/RefCountedPtr.h
+++ b/Source/LuaBridge/RefCountedPtr.h
@@ -34,7 +34,11 @@
 # include <hash_map>
 #else
 # include <stdint.h>
+#ifdef __GNUC__
+#include <unordered_map>
+#else
 # include <ext/hash_map>
+#endif
 #endif
 
 //==============================================================================
@@ -46,6 +50,8 @@ struct RefCountedPtrBase
   // Declaration of container for the refcounts
 #ifdef _MSC_VER
   typedef stdext::hash_map <const void *, int> RefCountsType;
+#elif __GNUC__
+  typedef std::unordered_map<const void *, int> RefCountsType;
 #else
   struct ptr_hash
   {


### PR DESCRIPTION
Using gcc-4.8.2:

In file included from /usr/include/c++/4.8.2/ext/hash_map:60:0,
                 from ./LuaBridge/Source/LuaBridge/RefCountedPtr.h:37,
                 from c++bridge.cpp:6:
/usr/include/c++/4.8.2/backward/backward_warning.h:32:2: Warnung: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
 #warning \
  ^

I am not sure what non-MSC compilers are supposed to be (besides gcc). Perhaps a GCC version check is necessary too?
