### PR TITLE
Issue #66 fixed

### DIFF
--- a/Source/LuaBridge/detail/Stack.h
+++ b/Source/LuaBridge/detail/Stack.h
@@ -457,7 +457,7 @@ struct Stack <std::string const&>
 {
   static inline void push (lua_State* L, std::string const& str)
   {
-    lua_pushstring (L, str.c_str(), str.size());
+    lua_pushlstring (L, str.c_str(), str.size());
   }
 
   static inline std::string get (lua_State* L, int index)


### PR DESCRIPTION
Because of a typo lua_pushstring function that takes 2 arguments was called instead of lua_pushlstring that takes 3 arguments, causing compile error.
