### PR TITLE
win32 __stdcall support

### DIFF
--- a/Source/LuaBridge/detail/FuncTraits.h
+++ b/Source/LuaBridge/detail/FuncTraits.h
@@ -178,6 +178,127 @@ struct FuncTraits <R (*) (P1, P2, P3, P4, P5, P6, P7, P8), D>
   }
 };
 
+#ifdef WIN32
+/* Ordinary function pointers with __stdcall. */
+
+template <class R, class D>
+struct FuncTraits <R(__stdcall *) (), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef None Params;
+	static R call(D fp, TypeListValues <Params>)
+	{
+		return fp();
+	}
+};
+
+template <class R, class P1, class D>
+struct FuncTraits <R(__stdcall *) (P1), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef TypeList <P1> Params;
+	static R call(D fp, TypeListValues <Params> tvl)
+	{
+		return fp(tvl.hd);
+	}
+};
+
+template <class R, class P1, class P2, class D>
+struct FuncTraits <R(__stdcall *) (P1, P2), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef TypeList <P1, TypeList <P2> > Params;
+	static R call(D fp, TypeListValues <Params> tvl)
+	{
+		return fp(tvl.hd, tvl.tl.hd);
+	}
+};
+
+template <class R, class P1, class P2, class P3, class D>
+struct FuncTraits <R(__stdcall *) (P1, P2, P3), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef TypeList <P1, TypeList <P2, TypeList <P3> > > Params;
+	static R call(D fp, TypeListValues <Params> tvl)
+	{
+		return fp(tvl.hd, tvl.tl.hd, tvl.tl.tl.hd);
+	}
+};
+
+template <class R, class P1, class P2, class P3, class P4, class D>
+struct FuncTraits <R(__stdcall *) (P1, P2, P3, P4), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef TypeList <P1, TypeList <P2, TypeList <P3, TypeList <P4> > > > Params;
+	static R call(D fp, TypeListValues <Params> tvl)
+	{
+		return fp(tvl.hd, tvl.tl.hd, tvl.tl.tl.hd, tvl.tl.tl.tl.hd);
+	}
+};
+
+template <class R, class P1, class P2, class P3, class P4, class P5, class D>
+struct FuncTraits <R(__stdcall *) (P1, P2, P3, P4, P5), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef TypeList <P1, TypeList <P2, TypeList <P3, TypeList <P4, TypeList <P5> > > > > Params;
+	static R call(D fp, TypeListValues <Params> tvl)
+	{
+		return fp(tvl.hd, tvl.tl.hd, tvl.tl.tl.hd, tvl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.hd);
+	}
+};
+
+template <class R, class P1, class P2, class P3, class P4, class P5, class P6, class D>
+struct FuncTraits <R(__stdcall *) (P1, P2, P3, P4, P5, P6), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef TypeList <P1, TypeList <P2, TypeList <P3, TypeList <P4, TypeList <P5, TypeList <P6> > > > > > Params;
+	static R call(D fp, TypeListValues <Params> tvl)
+	{
+		return fp(tvl.hd, tvl.tl.hd, tvl.tl.tl.hd, tvl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.tl.hd);
+	}
+};
+
+template <class R, class P1, class P2, class P3, class P4, class P5, class P6, class P7, class D>
+struct FuncTraits <R(__stdcall *) (P1, P2, P3, P4, P5, P6, P7), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef TypeList <P1, TypeList <P2, TypeList <P3, TypeList <P4, TypeList <P5, TypeList <P6, TypeList <P7> > > > > > > Params;
+	static R call(D fp, TypeListValues <Params> tvl)
+	{
+		return fp(tvl.hd, tvl.tl.hd, tvl.tl.tl.hd, tvl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.tl.tl.hd);
+	}
+};
+
+template <class R, class P1, class P2, class P3, class P4, class P5, class P6, class P7, class P8, class D>
+struct FuncTraits <R(__stdcall *) (P1, P2, P3, P4, P5, P6, P7, P8), D>
+{
+	static bool const isMemberFunction = false;
+	typedef D DeclType;
+	typedef R ReturnType;
+	typedef TypeList <P1, TypeList <P2, TypeList <P3, TypeList <P4, TypeList <P5, TypeList <P6, TypeList <P7, TypeList <P8> > > > > > > > Params;
+	static R call(D fp, TypeListValues <Params> tvl)
+	{
+		return fp(tvl.hd, tvl.tl.hd, tvl.tl.tl.hd, tvl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.tl.tl.hd, tvl.tl.tl.tl.tl.tl.tl.tl.hd);
+	}
+};
+#endif
+
 /* Non-const member function pointers. */
 
 template <class T, class R, class D>


### PR DESCRIPTION
it will allow developer to bind WinAPIs directly like:
getGlobalNamespace(L)
    .addFunction("GetAsyncKeyState", GetAsyncKeyState)
