### PR TITLE
Fix build issues

### DIFF
--- a/Source/LuaBridge/LuaBridge.h
+++ b/Source/LuaBridge/LuaBridge.h
@@ -51,20 +51,20 @@ namespace luabridge
 template <class T>
 struct Stack;
 
-#include "detail/LuaHelpers.h"
+#include <LuaBridge/detail/LuaHelpers.h>
 
-#include "detail/TypeTraits.h"
-#include "detail/TypeList.h"
-#include "detail/FuncTraits.h"
-#include "detail/Constructor.h"
-#include "detail/Stack.h"
-#include "detail/ClassInfo.h"
+#include <LuaBridge/detail/TypeTraits.h>
+#include <LuaBridge/detail/TypeList.h>
+#include <LuaBridge/detail/FuncTraits.h>
+#include <LuaBridge/detail/Constructor.h>
+#include <LuaBridge/detail/Stack.h>
+#include <LuaBridge/detail/ClassInfo.h>
 
 class LuaRef;
 
-#include "detail/LuaException.h"
-#include "detail/LuaRef.h"
-#include "detail/Iterator.h"
+#include <LuaBridge/detail/LuaException.h>
+#include <LuaBridge/detail/LuaRef.h>
+#include <LuaBridge/detail/Iterator.h>
 
 //------------------------------------------------------------------------------
 /**

--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -769,7 +769,7 @@ private:
     }
 
     // read-only
-    template <class TG, class TS>
+    template <class TG>
     Class <T>& addProperty (char const* name, TG (*get) (T const*))
     {
       // Add to __propget in class and const tables.


### PR DESCRIPTION
1. Fix template argument deduction/substitution failure:
```
...: error: no matching function for call to ‘luabridge::Namespace::Class<ClassX>::addProperty(const char [9], ClassY* (*)(const ClassX*))’

In file included from .../LuaBridge/LuaBridge.h:105:0,
                 from .../class_x.cpp:...:
.../Namespace.h:773:16: note: candidate: template<class TG, class TS> luabridge::Namespace::Class<T>& luabridge::Namespace::Class<T>::addProperty(const char*, TG (*)(const T*)) [with TG = TG; TS = TS; T = ClassX]
     Class <T>& addProperty (char const* name, TG (*get) (T const*))
                ^~~~~~~~~~~
.../LuaBridge/detail/Namespace.h:773:16: note:   template argument deduction/substitution failed:
.../class_x.cpp:...:...: note:   couldn't deduce template parameter ‘TS’
         .addProperty("property", &property)
                                           ^
```
Here obviously the TS typename is unused.

2. Fix the "internal" includes which however are totally external for clients because reside in the main header file. Since LuaBridge must be included as <LuaBridge/LuaBridge.h>, the details must be included as <LuaBridge/details/... .h>.