### PR TITLE
STL-style table iteration

### DIFF
--- a/Source/LuaBridge/detail/Iterator.h
+++ b/Source/LuaBridge/detail/Iterator.h
@@ -40,21 +40,31 @@ private:
   LuaRef m_key;
   LuaRef m_value;
 
+  void printStack ()
+  {
+    std::cerr << "===== Stack =====\n";
+    for (int i = 1; i <= lua_gettop (m_L); ++i)
+    {
+      std::cerr << "@" << i << " = " << luabridge::LuaRef::fromStack (m_L, i) << "\n";
+    }
+    std::cerr << "==========\n";
+  }
+
   void next ()
   {
-    m_table.push(m_L);
-    m_key.push (m_L);
+    m_table.push ();
+    m_key.push ();
     if (lua_next (m_L, -2))
     {
-      m_value.pop (m_L);
-      m_key.pop (m_L);
+      m_value.pop ();
+      m_key.pop ();
     }
     else
     {
-      m_key = Nil();
-      m_value = Nil();
+      m_key = Nil ();
+      m_value = Nil ();
     }
-    lua_pop(m_L, 1);
+    lua_pop (m_L, 1);
   }
 
 public:

--- a/Source/LuaBridge/detail/LuaRef.h
+++ b/Source/LuaBridge/detail/LuaRef.h
@@ -739,7 +739,7 @@ public:
     lua_getglobal (m_L, "tostring");
     push (m_L);
     lua_call (m_L, 1, 1);
-    const char* str = lua_tostring(m_L, 1);
+    const char* str = lua_tostring(m_L, -1);
     lua_pop(m_L, 1);
     return std::string(str);
   }
@@ -812,21 +812,31 @@ public:
   /**
       Place the object onto the Lua stack.
   */
+  void push () const
+  {
+    lua_rawgeti (m_L, LUA_REGISTRYINDEX, m_ref);
+  }
+
   void push (lua_State* L) const
   {
     assert (equalstates (L, m_L));
-    lua_rawgeti (L, LUA_REGISTRYINDEX, m_ref);
+    push ();
   }
 
   //----------------------------------------------------------------------------
   /**
       Pop the top of Lua stack and assign the ref to m_ref
   */
+  void pop ()
+  {
+    luaL_unref (m_L, LUA_REGISTRYINDEX, m_ref);
+    m_ref = luaL_ref (m_L, LUA_REGISTRYINDEX);
+  }
+
   void pop (lua_State* L)
   {
     assert (equalstates (L, m_L));
-    luaL_unref (m_L, LUA_REGISTRYINDEX, m_ref);
-    m_ref = luaL_ref (m_L, LUA_REGISTRYINDEX);
+    pop ();
   }
 
   //----------------------------------------------------------------------------

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (LUABRIDGE_TEST_SOURCE_FILES
   Source/IssueTests.cpp
+  Source/IteratorTests.cpp
   Source/LegacyTests.cpp
   Source/ListTests.cpp
   Source/LuaRefTests.cpp

--- a/Tests/Source/IteratorTests.cpp
+++ b/Tests/Source/IteratorTests.cpp
@@ -1,0 +1,45 @@
+// https://github.com/vinniefalco/LuaBridge
+//
+// Copyright 2018, Dmitry Tarakanov
+// SPDX-License-Identifier: MIT
+
+#include "TestBase.h"
+
+#include "LuaBridge/detail/Iterator.h"
+
+struct IteratorTests : TestBase
+{
+};
+
+TEST_F (IteratorTests, BasicIteration)
+{
+  runLua (
+    "result = {"
+    "  bool = true,"
+    "  int = 5,"
+    "  c = 3.14,"
+    "  [true] = 'D',"
+    "  [8] = 'abc',"
+    "  fn = function (i)"
+    "    result = i + 1"
+    "  end"
+    "}");
+
+    std::map <luabridge::LuaRef, luabridge::LuaRef> expected {
+        {{L, "bool"}, {L, true}},
+        {{L, "int"}, {L, 5}},
+        {{L, 'c'}, {L, 3.14}},
+        {{L, true}, {L, 'D'}},
+        {{L, 8}, {L, "abc"}},
+        {{L, "fn"}, {L, result () ["fn"]}},
+    };
+
+    std::map <luabridge::LuaRef, luabridge::LuaRef> actual;
+
+    for (luabridge::Iterator iterator (result ()); !iterator.isNil (); ++iterator)
+    {
+        actual.emplace(iterator.key (), iterator.value());
+    }
+
+    ASSERT_EQ (expected, actual);
+}

--- a/Tests/Source/IteratorTests.cpp
+++ b/Tests/Source/IteratorTests.cpp
@@ -11,7 +11,7 @@ struct IteratorTests : TestBase
 {
 };
 
-TEST_F (IteratorTests, BasicIteration)
+TEST_F (IteratorTests, DictionaryIteration)
 {
   runLua (
     "result = {"
@@ -25,21 +25,72 @@ TEST_F (IteratorTests, BasicIteration)
     "  end"
     "}");
 
-    std::map <luabridge::LuaRef, luabridge::LuaRef> expected {
-        {{L, "bool"}, {L, true}},
-        {{L, "int"}, {L, 5}},
-        {{L, 'c'}, {L, 3.14}},
-        {{L, true}, {L, 'D'}},
-        {{L, 8}, {L, "abc"}},
-        {{L, "fn"}, {L, result () ["fn"]}},
-    };
+  std::map <luabridge::LuaRef, luabridge::LuaRef> expected {
+    {{L, "bool"}, {L, true}},
+    {{L, "int"}, {L, 5}},
+    {{L, 'c'}, {L, 3.14}},
+    {{L, true}, {L, 'D'}},
+    {{L, 8}, {L, "abc"}},
+    {{L, "fn"}, {L, result () ["fn"]}},
+  };
 
-    std::map <luabridge::LuaRef, luabridge::LuaRef> actual;
+  std::map <luabridge::LuaRef, luabridge::LuaRef> actual;
 
-    for (luabridge::Iterator iterator (result ()); !iterator.isNil (); ++iterator)
-    {
-        actual.emplace(iterator.key (), iterator.value());
-    }
+  for (luabridge::Iterator iterator (result ()); !iterator.isNil (); ++iterator)
+  {
+    actual.emplace(iterator.key (), iterator.value());
+  }
 
-    ASSERT_EQ (expected, actual);
+  ASSERT_EQ (expected, actual);
+
+  actual.clear ();
+
+  for (auto&& pair : pairs (result ()))
+  {
+    actual.emplace (pair.first, pair.second);
+  }
+
+  ASSERT_EQ (expected, actual);
+}
+
+TEST_F (IteratorTests, SequenceIteration)
+{
+  runLua (
+    "result = {"
+    "  true,"
+    "  5,"
+    "  3.14,"
+    "  'D',"
+    "  'abc',"
+    "  function (i)"
+    "    result = i + 1"
+    "  end"
+    "}");
+
+  std::map <luabridge::LuaRef, luabridge::LuaRef> expected {
+    {{L, 1}, {L, true}},
+    {{L, 2}, {L, 5}},
+    {{L, 3}, {L, 3.14}},
+    {{L, 4}, {L, 'D'}},
+    {{L, 5}, {L, "abc"}},
+    {{L, 6}, {L, result () [6]}},
+  };
+
+  std::map <luabridge::LuaRef, luabridge::LuaRef> actual;
+
+  for (luabridge::Iterator iterator (result ()); !iterator.isNil (); ++iterator)
+  {
+    actual.emplace(iterator.key (), iterator.value());
+  }
+
+  ASSERT_EQ (expected, actual);
+
+  actual.clear ();
+
+  for (auto&& pair : pairs (result ()))
+  {
+    actual.emplace (pair.first, pair.second);
+  }
+
+  ASSERT_EQ (expected, actual);
 }

--- a/Tests/Source/LuaRefTests.cpp
+++ b/Tests/Source/LuaRefTests.cpp
@@ -198,5 +198,4 @@ TEST_F (LuaRefTests, Comparison)
   ASSERT_FALSE (t1 >= t2);
   ASSERT_TRUE (t1 >= t3);
   ASSERT_TRUE (t2 >= t3);
-
 }

--- a/Tests/Source/TestBase.h
+++ b/Tests/Source/TestBase.h
@@ -82,4 +82,13 @@ struct TestBase : public ::testing::Test
   {
     luabridge::setGlobal (L, luabridge::LuaRef (L), "result");
   }
+
+  void printStack ()
+  {
+    std::cerr << "===== Stack =====\n";
+    for (int i = 1; i <= lua_gettop (L); ++i)
+    {
+      std::cerr << "@" << i << " = " << luabridge::LuaRef::fromStack (L, i) << "\n";
+    }
+  }
 };

--- a/Tests/Source/Tests.cpp
+++ b/Tests/Source/Tests.cpp
@@ -39,16 +39,6 @@ void printValue (lua_State* L, int index)
   std::cerr << ": " << lua_typename (L, type) << " (" << type << ")" << std::endl;
 }
 
-void printStack (lua_State* L)
-{
-  std::cerr << "===== Stack =====\n";
-  for (int i = 1; i <= lua_gettop (L); ++i)
-  {
-    std::cerr << "@" << i << " = ";
-    printValue (L, i);
-  }
-}
-
 struct LuaBridgeTest : public TestBase
 {
 };


### PR DESCRIPTION
* Add `pairs (LuaRef)` function returning Iterator range
* Add `Iterator::operator!= (LuaRef)` function
* `Iterator::operator* ()` now returns std::pair of key and value
* Add `LuaRef::push ()` and `LuaRef::pop ()` functions