### PR TITLE
Forbid addVariable and addProperty to global namespace

### DIFF
--- a/Source/LuaBridge/detail/LuaRef.h
+++ b/Source/LuaBridge/detail/LuaRef.h
@@ -1,7 +1,8 @@
 //------------------------------------------------------------------------------
 /*
   https://github.com/vinniefalco/LuaBridge
-  
+
+  Copyright 2018, Dmitry Tarakanov
   Copyright 2012, Vinnie Falco <vinnie.falco@gmail.com>
   Copyright 2008, Nigel Atkinson <suprapilot+LuaCode@gmail.com>
 
@@ -269,7 +270,7 @@ public:
   template <class T>
   LuaRef& operator= (T rhs)
   {
-    LuaRef ref (rhs);
+    LuaRef ref (m_L, rhs);
     swap (ref);
     return *this;
   }

--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -748,8 +748,8 @@ private:
       Both the get and the set functions require a T const* and T* in the first
       argument respectively.
     */
-    template <class TG, class TS>
-    Class <T>& addProperty (char const* name, TG (*get) (T const*), void (*set) (T*, TS))
+    template <class TG, class TS = TG>
+    Class <T>& addProperty (char const* name, TG (*get) (T const*), void (*set) (T*, TS) = 0)
     {
       // Add to __propget in class and const tables.
       {
@@ -775,24 +775,6 @@ private:
         rawsetfield (L, -2, name);
         lua_pop (L, 1);
       }
-
-      return *this;
-    }
-
-    // read-only
-    template <class TG>
-    Class <T>& addProperty (char const* name, TG (*get) (T const*))
-    {
-      // Add to __propget in class and const tables.
-      rawgetfield (L, -2, "__propget");
-      rawgetfield (L, -4, "__propget");
-      typedef TG (*get_t) (T const*);
-      new (lua_newuserdata (L, sizeof (get_t))) get_t (get);
-      lua_pushcclosure (L, &CFunc::Call <get_t>::f, 1);
-      lua_pushvalue (L, -1);
-      rawsetfield (L, -4, name);
-      rawsetfield (L, -2, name);
-      lua_pop (L, 2);
 
       return *this;
     }
@@ -879,10 +861,9 @@ private:
   */
   explicit Namespace (lua_State* L_)
     : L (L_)
-    , m_stackSize (0)
+    , m_stackSize (1)
   {
     lua_getglobal (L, "_G");
-    ++m_stackSize;
   }
 
   //----------------------------------------------------------------------------
@@ -1016,6 +997,11 @@ public:
   template <class T>
   Namespace& addVariable (char const* name, T* pt, bool isWritable = true)
   {
+    if (m_stackSize == 1)
+    {
+      throw std::logic_error ("Unsupported addVariable on global namespace");
+    }
+
     assert (lua_istable (L, -1));
 
     rawgetfield (L, -1, "__propget");
@@ -1049,9 +1035,14 @@ public:
 
       If the set function is omitted or null, the property is read-only.
   */
-  template <class TG, class TS>
+  template <class TG, class TS = TG>
   Namespace& addProperty (char const* name, TG (*get) (), void (*set)(TS) = 0)
   {
+    if (m_stackSize == 1)
+    {
+      throw std::logic_error ("Unsupported addProperty on global namespace");
+    }
+
     assert (lua_istable (L, -1));
 
     rawgetfield (L, -1, "__propget");

--- a/Source/LuaBridge/detail/dump.h
+++ b/Source/LuaBridge/detail/dump.h
@@ -58,25 +58,7 @@ std::string dumpLuaState(lua_State *L) {
 		}
 	}
 	return ostr.str();
-}
 
-void printStack (const char* title) const
-{
-  std::cerr << "===== Stack : " << title << " =====\n";
-  for (int i = 1; i <= lua_gettop (L); ++i)
-  {
-    std::cerr << "@" << i << " = " << luabridge::LuaRef::fromStack (L, i) << "\n";
-  }
-}
-
-void printTable (int index, const char* name) const
-{
-  auto table = LuaRef::fromStack (L, index);
-  std::cerr << "===== " << name << ": " << table << " =====\n";
-  for (auto&& pair : pairs (table))
-  {
-    std::cerr << "[" << pair.first << "] = " << pair.second << "\n";
-  }
 }
 
 } // namespace luabridge

--- a/Source/LuaBridge/detail/dump.h
+++ b/Source/LuaBridge/detail/dump.h
@@ -60,4 +60,23 @@ std::string dumpLuaState(lua_State *L) {
 	return ostr.str();
 }
 
+void printStack (const char* title) const
+{
+  std::cerr << "===== Stack : " << title << " =====\n";
+  for (int i = 1; i <= lua_gettop (L); ++i)
+  {
+    std::cerr << "@" << i << " = " << luabridge::LuaRef::fromStack (L, i) << "\n";
+  }
+}
+
+void printTable (int index, const char* name) const
+{
+  auto table = LuaRef::fromStack (L, index);
+  std::cerr << "===== " << name << ": " << table << " =====\n";
+  for (auto&& pair : pairs (table))
+  {
+    std::cerr << "[" << pair.first << "] = " << pair.second << "\n";
+  }
+}
+
 } // namespace luabridge

--- a/Source/LuaBridge/detail/dump.h
+++ b/Source/LuaBridge/detail/dump.h
@@ -58,7 +58,6 @@ std::string dumpLuaState(lua_State *L) {
 		}
 	}
 	return ostr.str();
-
 }
 
 } // namespace luabridge

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,10 +1,12 @@
 set (LUABRIDGE_TEST_SOURCE_FILES
+  Source/ClassTests.cpp
   Source/IssueTests.cpp
   Source/IteratorTests.cpp
   Source/LegacyTests.cpp
   Source/ListTests.cpp
   Source/LuaRefTests.cpp
   Source/MapTests.cpp
+  Source/NamespaceTests.cpp
   Source/PerformanceTests.cpp
   Source/Tests.cpp
   Source/TestBase.h

--- a/Tests/Source/ClassTests.cpp
+++ b/Tests/Source/ClassTests.cpp
@@ -1,0 +1,152 @@
+// https://github.com/vinniefalco/LuaBridge
+//
+// Copyright 2018, Dmitry Tarakanov
+// SPDX-License-Identifier: MIT
+
+#include "TestBase.h"
+
+struct ClassTests : TestBase
+{
+  template <class T>
+  T variable (const std::string& name)
+  {
+    runLua ("result = " + name);
+    return result ().cast <T>();
+  }
+};
+
+namespace {
+
+template <class T>
+struct DataClass
+{
+  DataClass (T data)
+    : data (data)
+  {
+  }
+
+  static T getData (const DataClass* object)
+  {
+    return object->data;
+  }
+
+  static void setData (DataClass* object, T data)
+  {
+    object->data = data;
+  }
+
+  mutable T data;
+};
+
+} // namespace
+
+TEST_F (ClassTests, Data)
+{
+  using IntClass = DataClass <int>;
+  using AnyClass = DataClass <luabridge::LuaRef>;
+
+  luabridge::getGlobalNamespace (L)
+    .beginClass <IntClass> ("IntClass")
+    .addConstructor <void (*) (int)> ()
+    .addData ("data", &IntClass::data)
+    .endClass ();
+
+  runLua ("result = IntClass (501)");
+  ASSERT_TRUE (result () ["data"].isNumber ());
+  ASSERT_EQ (501, result () ["data"].cast <int> ());
+
+  runLua ("result.data = 2");
+  ASSERT_TRUE (result () ["data"].isNumber ());
+  ASSERT_EQ (2, result () ["data"].cast <int> ());
+
+  luabridge::getGlobalNamespace (L)
+    .beginNamespace ("ns")
+    .beginClass <AnyClass> ("AnyClass")
+    .addConstructor <void (*) (luabridge::LuaRef)> ()
+    .addData ("data", &AnyClass::data)
+    .endClass ()
+    .endNamespace ();
+
+  runLua ("result = ns.AnyClass ({a = 31})");
+  ASSERT_TRUE (result () ["data"].isTable ());
+  ASSERT_TRUE (result () ["data"] ["a"].isNumber ());
+  ASSERT_EQ (31, result () ["data"] ["a"].cast <int> ());
+
+  runLua ("result.data = true");
+  ASSERT_TRUE (result () ["data"].isBool ());
+  ASSERT_EQ (true, result () ["data"].cast <bool> ());
+}
+
+TEST_F (ClassTests, Properties)
+{
+  using IntClass = DataClass <int>;
+  using AnyClass = DataClass <luabridge::LuaRef>;
+
+  luabridge::getGlobalNamespace (L)
+    .beginClass <IntClass> ("IntClass")
+    .addConstructor <void (*) (int)> ()
+    .addProperty ("data", &IntClass::getData, &IntClass::setData)
+    .endClass ();
+
+  runLua ("result = IntClass (501)");
+  ASSERT_TRUE (result () ["data"].isNumber ());
+  ASSERT_EQ (501, result () ["data"].cast <int> ());
+
+  runLua ("result.data = -2");
+  ASSERT_TRUE (result () ["data"].isNumber ());
+  ASSERT_EQ (-2, result () ["data"].cast <int> ());
+
+  luabridge::getGlobalNamespace (L)
+    .beginNamespace ("ns")
+    .beginClass <AnyClass> ("AnyClass")
+    .addConstructor <void (*) (luabridge::LuaRef)> ()
+    .addProperty ("data", &AnyClass::getData, &AnyClass::setData)
+    .endClass ()
+    .endNamespace ();
+
+  runLua ("result = ns.AnyClass ({a = 31})");
+  ASSERT_TRUE (result () ["data"].isTable ());
+  ASSERT_TRUE (result () ["data"] ["a"].isNumber ());
+  ASSERT_EQ (31, result () ["data"] ["a"].cast <int> ());
+
+  runLua ("result.data = 'abc'");
+  ASSERT_TRUE (result () ["data"].isString ());
+  ASSERT_EQ ("abc", result () ["data"].cast <std::string> ());
+}
+
+TEST_F (ClassTests, ReadOnlyProperties)
+{
+  using IntClass = DataClass <int>;
+  using AnyClass = DataClass <luabridge::LuaRef>;
+
+  luabridge::getGlobalNamespace (L)
+    .beginClass <IntClass> ("IntClass")
+    .addConstructor <void (*) (int)> ()
+    .addProperty ("data", &IntClass::getData)
+    .endClass ();
+
+  runLua ("result = IntClass (501)");
+  ASSERT_TRUE (result () ["data"].isNumber ());
+  ASSERT_EQ (501, result () ["data"].cast <int> ());
+
+  ASSERT_THROW (runLua ("result.data = -2"), std::runtime_error);
+  ASSERT_EQ (501, result () ["data"].cast <int> ());
+
+  luabridge::getGlobalNamespace (L)
+    .beginNamespace ("ns")
+    .beginClass <AnyClass> ("AnyClass")
+    .addConstructor <void (*) (luabridge::LuaRef)> ()
+    .addProperty ("data", &AnyClass::getData)
+    .endClass ()
+    .endNamespace ();
+
+  runLua ("result = ns.AnyClass ({a = 31})");
+  ASSERT_TRUE (result () ["data"].isTable ());
+  ASSERT_TRUE (result () ["data"] ["a"].isNumber ());
+  ASSERT_EQ (31, result () ["data"] ["a"].cast <int> ());
+
+  ASSERT_THROW (runLua ("result.data = 'abc'"), std::runtime_error);
+  ASSERT_TRUE (result () ["data"].isTable ());
+  ASSERT_TRUE (result () ["data"] ["a"].isNumber ());
+  ASSERT_EQ (31, result () ["data"] ["a"].cast <int> ());
+}

--- a/Tests/Source/MapTests.cpp
+++ b/Tests/Source/MapTests.cpp
@@ -1,8 +1,6 @@
 // https://github.com/vinniefalco/LuaBridge
 //
 // Copyright 2018, Dmitry Tarakanov
-// Copyright 2012, Vinnie Falco <vinnie.falco@gmail.com>
-// Copyright 2007, Nathan Reed
 // SPDX-License-Identifier: MIT
 
 #include "TestBase.h"

--- a/Tests/Source/NamespaceTests.cpp
+++ b/Tests/Source/NamespaceTests.cpp
@@ -1,0 +1,149 @@
+// https://github.com/vinniefalco/LuaBridge
+//
+// Copyright 2018, Dmitry Tarakanov
+// SPDX-License-Identifier: MIT
+
+#include "TestBase.h"
+
+struct NamespaceTests : TestBase
+{
+  template <class T>
+  T variable (const std::string& name)
+  {
+    runLua ("result = " + name);
+    return result ().cast <T>();
+  }
+};
+
+TEST_F (NamespaceTests, Variables)
+{
+  int int_ = -10;
+  auto any = luabridge::newTable (L);
+  any ["a"] = 1;
+
+  ASSERT_THROW (
+    luabridge::getGlobalNamespace (L).addVariable ("int", &int_),
+    std::logic_error);
+
+  runLua ("result = int");
+  ASSERT_TRUE (result ().isNil ());
+
+  luabridge::getGlobalNamespace (L)
+    .beginNamespace ("ns")
+    .addVariable ("int", &int_)
+    .addVariable ("any", &any)
+    .endNamespace ();
+
+  ASSERT_EQ (-10, variable <int> ("ns.int"));
+  ASSERT_EQ (any, variable <luabridge::LuaRef> ("ns.any"));
+
+  runLua ("ns.int = -20");
+  ASSERT_EQ (-20, int_);
+
+  runLua ("ns.any = {b = 2}");
+  ASSERT_TRUE (any.isTable ());
+  ASSERT_TRUE (any ["b"].isNumber ());
+  ASSERT_EQ (2, any ["b"].cast <int> ());
+}
+
+TEST_F (NamespaceTests, ReadOnlyVariables)
+{
+  int int_ = -10;
+  auto any = luabridge::newTable (L);
+  any["a"] = 1;
+
+  ASSERT_THROW (
+    luabridge::getGlobalNamespace (L).addVariable ("int", &int_),
+    std::logic_error);
+
+  runLua ("result = int");
+  ASSERT_TRUE (result ().isNil ());
+
+  luabridge::getGlobalNamespace (L)
+    .beginNamespace ("ns")
+    .addVariable ("int", &int_, false)
+    .addVariable ("any", &any, false)
+    .endNamespace ();
+
+  ASSERT_EQ (-10, variable <int> ("ns.int"));
+  ASSERT_EQ (any, variable <luabridge::LuaRef> ("ns.any"));
+
+  ASSERT_THROW (runLua ("ns.int = -20"), std::runtime_error);
+  ASSERT_EQ (-10, variable <int> ("ns.int"));
+
+  ASSERT_THROW (runLua ("ns.any = {b = 2}"), std::runtime_error);
+  ASSERT_EQ (any, variable <luabridge::LuaRef> ("ns.any"));
+}
+
+namespace {
+
+template <class T>
+struct Property
+{
+  static T value;
+};
+
+template <class T>
+T Property <T>::value;
+
+template <class T>
+void setProperty (const T& value)
+{
+  Property <T>::value = value;
+}
+
+template <class T>
+const T& getProperty ()
+{
+  return Property <T>::value;
+}
+
+} // namespace
+
+TEST_F (NamespaceTests, Properties)
+{
+  setProperty <int> (-10);
+
+  ASSERT_THROW (
+    luabridge::getGlobalNamespace (L)
+      .addProperty ("int", &getProperty <int>, &setProperty <int>),
+    std::logic_error);
+
+  runLua ("result = int");
+  ASSERT_TRUE (result ().isNil ());
+
+  luabridge::getGlobalNamespace (L)
+    .beginNamespace ("ns")
+      .addProperty ("int", &getProperty <int>, &setProperty <int>)
+    .endNamespace ();
+
+  ASSERT_EQ (-10, variable <int> ("ns.int"));
+
+  runLua ("ns.int = -20");
+  ASSERT_EQ (-20, getProperty <int> ());
+}
+
+TEST_F (NamespaceTests, ReadOnlyProperties)
+{
+  setProperty <int> (-10);
+
+  ASSERT_THROW (
+    luabridge::getGlobalNamespace (L)
+      .addProperty ("int", &getProperty <int>),
+    std::logic_error);
+
+  runLua ("result = int");
+  ASSERT_TRUE (result ().isNil ());
+
+  luabridge::getGlobalNamespace (L)
+    .beginNamespace ("ns")
+      .addProperty ("int", &getProperty <int>)
+    .endNamespace ();
+
+  ASSERT_EQ (-10, variable <int> ("ns.int"));
+
+  ASSERT_THROW (
+    runLua ("ns.int = -20"),
+    std::runtime_error);
+  ASSERT_EQ (-10, getProperty <int> ());
+}

--- a/Tests/Source/Tests.cpp
+++ b/Tests/Source/Tests.cpp
@@ -188,53 +188,6 @@ struct TestClass
   mutable T constData;
 };
 
-TEST_F (LuaBridgeTest, ClassData)
-{
-  luabridge::getGlobalNamespace (L)
-    .beginClass <TestClass <int> > ("IntClass")
-    .addConstructor <void (*) (int)> ()
-    .addData ("data", &TestClass <int>::data)
-    .addData ("constData", &TestClass <int>::constData, false)
-    .endClass ()
-    .beginClass <TestClass <std::string> > ("StringClass")
-    .addConstructor <void (*) (std::string)> ()
-    .addData ("data", &TestClass <std::string>::data)
-    .addData ("constData", &TestClass <std::string>::constData, false)
-    .endClass ()
-    ;
-
-  runLua ("result = IntClass (501)");
-  ASSERT_TRUE (result ().isUserdata ());
-  ASSERT_TRUE (result () ["data"].isNumber ());
-  ASSERT_EQ (501, result () ["data"].cast <int> ());
-  ASSERT_TRUE (result () ["data"].isNumber ());
-  ASSERT_EQ (501, result () ["constData"].cast <int> ());
-
-  ASSERT_THROW (
-    runLua ("IntClass (501).constData = 2"),
-    std::runtime_error);
-
-  runLua ("result = IntClass (501) result.data = 2");
-  ASSERT_EQ (2, result () ["data"].cast <int> ());
-  ASSERT_EQ (501, result () ["constData"].cast <int> ());
-
-  runLua ("result = StringClass ('abc')");
-  ASSERT_TRUE (result ().isUserdata ());
-  ASSERT_TRUE (result () ["data"].isString ());
-  ASSERT_EQ ("abc", result () ["data"].cast <std::string> ());
-  ASSERT_TRUE (result () ["constData"].isString ());
-  ASSERT_EQ ("abc", result () ["constData"].cast <std::string> ());
-
-  ASSERT_THROW (
-    runLua ("StringClass ('abc').constData = 'd'"),
-    std::runtime_error);
-
-  runLua ("result = StringClass ('abc') result.data = 'd'");
-  ASSERT_EQ ("d", result () ["data"].cast <std::string> ());
-  ASSERT_EQ ("abc", result () ["constData"].cast <std::string> ());
-}
-
-
 TEST_F (LuaBridgeTest, ClassFunction)
 {
   typedef TestClass <int> Inner;


### PR DESCRIPTION
* Forbid addVariable for global namespace.
* Forbid addProperty for global namespace.
* Add Namespace unit tests.
* Fix compilation error.