### PR TITLE
Fix 'warning: type qualifiers ignored on function return type'

### DIFF
--- a/Source/LuaBridge/detail/Userdata.h
+++ b/Source/LuaBridge/detail/Userdata.h
@@ -63,7 +63,7 @@ protected:
   /**
     Get an untyped pointer to the contained class.
   */
-  void* const getPointer ()
+  void* getPointer ()
   {
     return m_p;
   }


### PR DESCRIPTION
such const qualifier useless anyway