### PR TITLE
Adding LuaRefBase::isInstance<T>() 

### DIFF
--- a/Source/LuaBridge/detail/LuaRef.h
+++ b/Source/LuaBridge/detail/LuaRef.h
@@ -306,11 +306,11 @@ public:
       Type check
   */
   template <class T>
-  bool isInstance() const
+  bool isInstance () const
   {
-    StackPop p(m_L, 1);
-    impl().push();
-    return Stack <T>::isInstance(m_L, -1);
+    StackPop p (m_L, 1);
+    impl ().push ();
+    return Stack <T>::isInstance (m_L, -1);
   }
 
   //----------------------------------------------------------------------------

--- a/Source/LuaBridge/detail/LuaRef.h
+++ b/Source/LuaBridge/detail/LuaRef.h
@@ -303,6 +303,18 @@ public:
 
   //----------------------------------------------------------------------------
   /**
+      Type check
+  */
+  template <class T>
+  bool isInstance() const
+  {
+    StackPop p(m_L, 1);
+    impl().push();
+    return Stack <T>::isInstance(m_L, -1);
+  }
+
+  //----------------------------------------------------------------------------
+  /**
       Universal implicit conversion operator.
 
       NOTE: Visual Studio 2010 and 2012 have a bug where this function

--- a/Source/LuaBridge/detail/Userdata.h
+++ b/Source/LuaBridge/detail/Userdata.h
@@ -156,7 +156,11 @@ private:
   {
     index = lua_absindex (L, index);
 
-    lua_getmetatable (L, index); // Stack: object metatable (ot) | nil
+    int result = lua_getmetatable (L, index); // Stack: object metatable (ot) | nothing
+    if (result == 0)
+    {
+      return false; // Nothing was pushed on the stack
+    }
     if (!lua_istable (L, -1))
     {
       lua_pop (L, 1); // Stack: -


### PR DESCRIPTION
There were special isBool, isNumber etc functipons for LuaRef, but it was not possible to determine if a LuaRef object is an instance of a class registered to a Namespace via beginClass().

LuaRefBase::isInstance also works as a general type check function and besides registered classes, it can be used with simple LUA types like bool, string, number.