### PR TITLE
warning C26495: Variable 'luabridge::Userdata::m_p' is uninitialized.…

### DIFF
--- a/Source/LuaBridge/detail/Userdata.h
+++ b/Source/LuaBridge/detail/Userdata.h
@@ -59,7 +59,7 @@ class Userdata
 protected:
   void* m_p; // subclasses must set this
 
-  Userdata() : m_p(nullptr)
+  Userdata() : m_p (0)
   {	  
   }
 	

--- a/Source/LuaBridge/detail/Userdata.h
+++ b/Source/LuaBridge/detail/Userdata.h
@@ -57,8 +57,12 @@ namespace luabridge {
 class Userdata
 {
 protected:
-  void* m_p = nullptr; // subclasses must set this
+  void* m_p; // subclasses must set this
 
+  Userdata() : m_p(nullptr)
+  {	  
+  }
+	
   //--------------------------------------------------------------------------
   /**
     Get an untyped pointer to the contained class.

--- a/Source/LuaBridge/detail/Userdata.h
+++ b/Source/LuaBridge/detail/Userdata.h
@@ -57,7 +57,7 @@ namespace luabridge {
 class Userdata
 {
 protected:
-  void* m_p; // subclasses must set this
+  void* m_p = nullptr; // subclasses must set this
 
   //--------------------------------------------------------------------------
   /**


### PR DESCRIPTION
… Always initialize a member variable (type.6).

We get this static code analysis warning when using luabridge in a project with c++17 VS2019