### PR TITLE
docs: fix simple typo, funtion -> function

### DIFF
--- a/Tests/Lua/Lua.5.1.5/src/ldo.h
+++ b/Tests/Lua/Lua.5.1.5/src/ldo.h
@@ -31,7 +31,7 @@
 /* results from luaD_precall */
 #define PCRLUA		0	/* initiated a call to a Lua function */
 #define PCRC		1	/* did a call to a C function */
-#define PCRYIELD	2	/* C funtion yielded */
+#define PCRYIELD	2	/* C function yielded */
 
 
 /* type of protected functions, to be ran by `runprotected' */


### PR DESCRIPTION
There is a small typo in Tests/Lua/Lua.5.1.5/src/ldo.h.

Should read `function` rather than `funtion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md