### PR TITLE
Fix stl::array integration (get)

### DIFF
--- a/Source/LuaBridge/Array.h
+++ b/Source/LuaBridge/Array.h
@@ -30,7 +30,6 @@ struct Stack<std::array<T, s>>
         if (!lua_istable(L, index))
         {
             luaL_error(L, "#%d argments must be table", index);
-            throw std::runtime_error("Array get () must receive a table");
         }
 
         std::size_t const tableSize = static_cast<std::size_t>(get_length(L, index));

--- a/Source/LuaBridge/Array.h
+++ b/Source/LuaBridge/Array.h
@@ -32,7 +32,10 @@ struct Stack<std::array<T, s>>
             luaL_error(L, "#%d argments must be table", index);
             throw std::runtime_error("Array get () must receive a table");
         }
-        if (index != s)
+
+        std::size_t const tableSize = static_cast<std::size_t>(get_length(L, index));
+
+        if (tableSize != s)
         {
             luaL_error(L, "array size should be %d ", s);
         }

--- a/Source/LuaBridge/Array.h
+++ b/Source/LuaBridge/Array.h
@@ -44,12 +44,12 @@ struct Stack<std::array<T, s>>
 
         int const absindex = lua_absindex(L, index);
         lua_pushnil(L);
-        int arr_index = 0;
+        int arrayIndex = 0;
         while (lua_next(L, absindex) != 0)
         {
-            array[arr_index] = Stack<T>::get(L, -1);
+            array[arrayIndex] = Stack<T>::get(L, -1);
             lua_pop(L, 1);
-            arr_index++;
+            ++arrayIndex;
         }
         return array;
     }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (LUABRIDGE_TEST_SOURCE_FILES
+  Source/ArrayTests.cpp
   Source/ClassTests.cpp
   Source/IssueTests.cpp
   Source/IteratorTests.cpp

--- a/Tests/Source/ArrayTests.cpp
+++ b/Tests/Source/ArrayTests.cpp
@@ -1,0 +1,99 @@
+// https://github.com/vinniefalco/LuaBridge
+// Copyright 2019, Dmitry Tarakanov
+// SPDX-License-Identifier: MIT
+
+#include "TestBase.h"
+#include "TestTypes.h"
+
+#include "LuaBridge/Array.h"
+
+#include <array>
+
+template<class T>
+struct ArrayTest : TestBase
+{
+};
+
+TYPED_TEST_CASE_P(ArrayTest);
+
+TYPED_TEST_P(ArrayTest, LuaRef)
+{
+    using Traits = TypeTraits<TypeParam>;
+
+    this->runLua("result = {" + Traits::list() + "}");
+
+    std::array<TypeParam, 3> expected;
+    std::copy_n(Traits::values().begin(), 3, expected.begin());
+
+    std::array<TypeParam, 3> actual = this->result();
+    ASSERT_EQ(expected, actual);
+}
+
+REGISTER_TYPED_TEST_CASE_P(ArrayTest, LuaRef);
+
+INSTANTIATE_TYPED_TEST_CASE_P(ArrayTest, ArrayTest, TestTypes);
+
+namespace {
+
+struct Data
+{
+    /* explicit */ Data(int i = -1000) : i(i) {}
+
+    int i;
+};
+
+bool operator==(const Data& lhs, const Data& rhs)
+{
+    return lhs.i == rhs.i;
+}
+
+std::ostream& operator<<(std::ostream& lhs, const Data& rhs)
+{
+    lhs << "{" << rhs.i << "}";
+    return lhs;
+}
+
+template<std::size_t S>
+std::array<Data, S> processValues(const std::array<Data, S>& data)
+{
+    return data;
+}
+
+template<std::size_t S>
+std::array<Data, S> processPointers(const std::array<const Data*, S>& data)
+{
+    std::array<Data, S> result;
+    std::size_t arrayIndex = 0;
+    for (const auto* item : data)
+    {
+        result[arrayIndex] = *item;
+        ++arrayIndex;
+    }
+    return result;
+}
+
+} // namespace
+
+struct ArrayTests : TestBase
+{
+};
+
+TEST_F(ArrayTests, PassFromLua)
+{
+    luabridge::getGlobalNamespace(L)
+        .beginClass<Data>("Data")
+        .addConstructor<void (*)(int)>()
+        .endClass()
+        .addFunction("processValues", &processValues<3>)
+        .addFunction("processPointers", &processPointers<3>);
+
+    resetResult();
+    runLua("result = processValues ({Data (-1), Data (2), Data (5)})");
+
+    ASSERT_EQ((std::array<Data, 3>({-1, 2, 5})), (result<std::array<Data, 3>>()));
+
+    resetResult();
+    runLua("result = processPointers ({Data (-3), Data (4), Data (9)})");
+
+    ASSERT_EQ((std::array<Data, 3>({-3, 4, 9})), (result<std::array<Data, 3>>()));
+}


### PR DESCRIPTION
Fixed stl::array get integration: Table size is not equal to index parameter. Furthermore added a test to verify the bug fix.