### PR TITLE
Fix minor issues of STL integration tests

### DIFF
--- a/Tests/Source/MapTests.cpp
+++ b/Tests/Source/MapTests.cpp
@@ -138,7 +138,7 @@ TEST_F(MapTests, PassFromLua)
 
     {
         resetResult();
-        runLua("result = processValues ({[Data (3)] = Data (-4)})");
+        runLua("result = processPointers ({[Data (3)] = Data (-4)})");
         std::map<Data, Data> expected{{Data(3), Data(-4)}};
         const auto actual = result<std::map<Data, Data>>();
         ASSERT_EQ(expected, actual);

--- a/Tests/Source/UnorderedMapTests.cpp
+++ b/Tests/Source/UnorderedMapTests.cpp
@@ -151,7 +151,7 @@ TEST_F(UnorderedMapTests, PassFromLua)
 
     {
         resetResult();
-        runLua("result = processValues ({[Data (3)] = Data (-4)})");
+        runLua("result = processPointers ({[Data (3)] = Data (-4)})");
         std::unordered_map<Data, Data> expected{{Data(3), Data(-4)}};
         const auto actual = result<std::unordered_map<Data, Data>>();
         ASSERT_EQ(expected, actual);

--- a/Tests/Source/VectorTests.cpp
+++ b/Tests/Source/VectorTests.cpp
@@ -87,7 +87,7 @@ TEST_F(VectorTests, PassFromLua)
     ASSERT_EQ(std::vector<Data>({-1, 2}), result<std::vector<Data>>());
 
     resetResult();
-    runLua("result = processValues ({Data (-3), Data (4)})");
+    runLua("result = processPointers ({Data (-3), Data (4)})");
 
     ASSERT_EQ(std::vector<Data>({-3, 4}), result<std::vector<Data>>());
 }


### PR DESCRIPTION
Fixed minor issues of STL integration tests: processPointers function wasn't called by lua test code.