### PR TITLE
Added support of constants

### DIFF
--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -1165,7 +1165,7 @@ public:
 
         return *this;
     }
-    
+    template<class T>
     Namespace& addConstant(char const* name, T value)
     {
         if (m_stackSize == 1)

--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -1165,6 +1165,21 @@ public:
 
         return *this;
     }
+    
+    Namespace& addConstant(char const* name, T value)
+    {
+        if (m_stackSize == 1)
+        {
+            throw std::logic_error("addConstant () called on global namespace");
+        }
+
+        assert(lua_istable(L, -1)); // Stack: namespace table (ns)
+
+        Stack<T>::push(L,value); // Stack: ns, value
+        rawsetfield(L, -2, name); // Stack: ns
+
+        return *this;
+    }
 
     //----------------------------------------------------------------------------
     /**


### PR DESCRIPTION
Now you can register constants into a namespace:
```
const int value=12;

getGlobalNamespace(L)
    .beginNamespace("Test")
        .addConstant("value",value)
    .endNamespace();
```
lua:
`print(Test.value) --12`

Registering of enums works too:
```
enum A{a,b,c,d};
getGlobalNamespace(L)
    .beginNamespace("A")
        .addConstant("a",A::a)
        .addConstant("b",A::b)
        .addConstant("c",A::c)
        .addConstant("d",A::d)
    .endNamespace();
```
lua:
```
print(A.a) --0
print(A.b) --1
print(A.c) --2
print(A.d) --3
```