### PR TITLE
Remove pointer from getRefCounts() after deleting.

### DIFF
--- a/Source/LuaBridge/RefCountedPtr.h
+++ b/Source/LuaBridge/RefCountedPtr.h
@@ -162,7 +162,10 @@ public:
         if (m_p != 0)
         {
             if (--getRefCounts()[m_p] <= 0)
+            {
                 delete m_p;
+                getRefCounts().erase(m_p);
+            }
 
             m_p = 0;
         }

--- a/Source/LuaBridge/RefCountedPtr.h
+++ b/Source/LuaBridge/RefCountedPtr.h
@@ -159,15 +159,18 @@ public:
     */
     void reset()
     {
-        if (m_p != 0)
+        auto myCount_it = getRefCounts().find(m_p); // use find() to avoid adding a spurious pointer to getRefCounts()
+        if (myCount_it != getRefCounts().end())
         {
-            if (--getRefCounts()[m_p] <= 0)
+            if (--myCount_it->second <= 0)
             {
-                delete m_p;
+                if (m_p != 0)
+                    delete m_p;
+                else
+                    int x = 1;
                 getRefCounts().erase(m_p);
+                m_p = 0;
             }
-
-            m_p = 0;
         }
     }
 


### PR DESCRIPTION
The list of pointers in `RefCountedPtr` currently grows without shrinking. That in itself could be seen as a memory leak. This pull request erases the pointer from the list after deleting.

In the same routine I also addressed the case where `RefCountedPtr` is initialized with `NULL`. This change allows it to unwind gracefully. In my testing, the referenced pointer map is now empty when the script exits.