### PR TITLE
exception handler needs to be able to access lua state

### DIFF
--- a/Source/LuaBridge/detail/LuaException.h
+++ b/Source/LuaBridge/detail/LuaException.h
@@ -67,6 +67,12 @@ public:
     */
     static void enableExceptions(lua_State* L) { lua_atpanic(L, throwAtPanic); }
 
+    /** Retrieve the lua_State associated with the exception.
+
+      @returns A Lua state.
+    */
+    lua_State* state() const { return m_L; }
+
 protected:
     void whatFromStack()
     {


### PR DESCRIPTION
Currently, `LuaException` provides no way to access its lua state. This pull request addresses that.