### PR TITLE
suppress unused variable warnings

### DIFF
--- a/Source/LuaBridge/detail/FuncTraits.h
+++ b/Source/LuaBridge/detail/FuncTraits.h
@@ -42,7 +42,7 @@ template<class ReturnType>
 struct Caller<ReturnType, 0>
 {
     template<class Fn, class Params>
-    static ReturnType f(Fn& fn, TypeListValues<Params>& params)
+    static ReturnType f(Fn& fn, TypeListValues<Params>& )
     {
         return fn();
     }

--- a/Source/LuaBridge/detail/Stack.h
+++ b/Source/LuaBridge/detail/Stack.h
@@ -23,7 +23,7 @@ struct Stack;
 template<>
 struct Stack<void>
 {
-    static void push(lua_State* L) {}
+    static void push(lua_State* ) {}
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request fixes a couple of minor "unused parameter" warnings. I have eliminated the parameter names rather than using the `[[maybe_unused]]` attribute introduced in C++17. This was to allow the code to continue to be C++11-compatible.

Resolves #264
