### PR TITLE
add property setter function that does not depend on getter

### DIFF
--- a/Manual.html
+++ b/Manual.html
@@ -723,6 +723,26 @@ getGlobalNamespace (L)
 </pre>
 
 <p>
+You can alternatively add property setters separately with <code>addPropertySetter</code>
+as follows.
+</p>
+
+<pre>
+getGlobalNamespace (L)
+ .beginNamespace ("test")
+    .beginClass &lt;A&gt; ("A")
+      .addProperty ("prop", &amp;A::getProperty)
+      .addPropertySetter ("prop", &amp;A::setProperty)
+    .endClass ()
+  .endNameSpace ();
+</pre>
+
+<p>
+This allows you to add your property setters and getters in any order. It is not required
+to add a getter if you want a write-only property.
+</p>
+
+<p>
 Method registration works just like function registration.  Virtual methods
 work normally; no special syntax is needed. const methods are detected and
 const-correctness is enforced, so if a function returns a const object (or

--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -642,6 +642,24 @@ class Namespace : public detail::Registrar
         /**
           Add or replace a property member.
         */
+        template<class TS>
+        Class<T>& addPropertySetter(char const* name, void (T::*set)(TS))
+        {
+            assertStackState(); // Stack: const table (co), class table (cl), static table (st)
+
+            typedef void (T::*set_t)(TS);
+            new (lua_newuserdata(L, sizeof(set_t)))
+                set_t(set); // Stack: co, cl, st, function ptr
+            lua_pushcclosure(L, &CFunc::CallMember<set_t>::f, 1); // Stack: co, cl, st, setter
+            CFunc::addSetter(L, name, -3); // Stack: co, cl, st
+
+            return *this;
+        }
+
+        //--------------------------------------------------------------------------
+        /**
+          Add or replace a property member.
+        */
         template<class TG, class TS = TG>
         Class<T>& addProperty(char const* name,
                               TG (T::*get)(lua_State*) const,


### PR DESCRIPTION
This pull request implements a separate `addPropertySetter` function for `Class`. If you use a reflection library like `refl-cpp` to load your classes into `LuaBridge`, it is inefficient or even impossible (due to Visual Studio 2019 limitations) to know the property getter and setter at the same time. This simple new function resolves the issue.

It would have been possible to overload `addProperty`, but that had the disadvantage of making it far too easy to add a setter instead of a getter by mistake (or vice versa). So I opted to give it a different function name.

Resolves #265
