### PR TITLE
fix compile error in c++20

### DIFF
--- a/Source/LuaBridge/detail/Userdata.h
+++ b/Source/LuaBridge/detail/Userdata.h
@@ -269,7 +269,7 @@ template<class T>
 class UserdataValue : public Userdata
 {
 private:
-    UserdataValue<T>(UserdataValue<T> const&);
+    UserdataValue(UserdataValue<T> const&);
     UserdataValue<T> operator=(UserdataValue<T> const&);
 
     char m_storage[sizeof(T)];


### PR DESCRIPTION
This pull request fixes UserdataValue's copy constructor compile error in c++20.