### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ cmake -G "Visual Studio 17 2022 Win64" -B build
 # Generates MSVS solution build/LuaBridge.sln
 ```
 
+## Installing LuaBridge(vcpkg)
+
+You can download and install LuaBridge using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```Powershell or bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+vcpkg install luabridge
+```
+
+The LuaBridge port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 # LuaBridge Demo
 
 LuaBridge provides both a command line program and a stand-alone graphical

--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ cmake -G "Visual Studio 17 2022 Win64" -B build
 # Generates MSVS solution build/LuaBridge.sln
 ```
 
-## Installing LuaBridge(vcpkg)
+## Installing LuaBridge (vcpkg)
 
 You can download and install LuaBridge using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 ```Powershell or bash
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
-./bootstrap-vcpkg.sh
+./bootstrap-vcpkg.sh # The name of the script shuold be "./bootstrap-vcpkg.bat" for Powershell
 ./vcpkg integrate install
-vcpkg install luabridge
+./vcpkg install luabridge
 ```
 
 The LuaBridge port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
`LuaBridge` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `LuaBridge` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `LuaBridge`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/luabridge/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)