### PR TITLE
Fix CMake in MSYS2 environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_dependent_option(LUABRIDGE_TESTING "Build tests" ON
     "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF
 )
 
-if(WIN32)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_compile_options(/MP)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_dependent_option(LUABRIDGE_TESTING "Build tests" ON
     "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF
 )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if(MSVC)
     add_compile_options(/MP)
 endif()
 


### PR DESCRIPTION
This fix only adds the /MP parameter to Visual Studio compilers instead of adding it to all compilers under Windows.
Without this change the build in a MSYS2 environment with a g++ compiler doesn't work.