### PR TITLE
Fix metatable security.

### DIFF
--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -1041,6 +1041,12 @@ private:
             lua_newtable(L); // Stack: pns, ns, propset table (ps)
             lua_rawsetp(L, -2, detail::getPropsetKey()); // ns [propsetKey] = ps. Stack: pns, ns
 
+			if (Security::hideMetatables())
+			{
+				lua_pushboolean(L, 0);
+				rawsetfield(L, -2, "__metatable");
+			}
+
             // pns [name] = ns
             lua_pushvalue(L, -1); // Stack: pns, ns, ns
             rawsetfield(L, -3, name); // Stack: pns, ns

--- a/Source/LuaBridge/detail/Namespace.h
+++ b/Source/LuaBridge/detail/Namespace.h
@@ -155,7 +155,7 @@ class Namespace : public detail::Registrar
 
             if (Security::hideMetatables())
             {
-                lua_pushnil(L);
+                lua_pushboolean(L, 0);
                 rawsetfield(L, -2, "__metatable");
             }
         }
@@ -221,7 +221,7 @@ class Namespace : public detail::Registrar
 
             if (Security::hideMetatables())
             {
-                lua_pushnil(L);
+                lua_pushboolean(L, 0);
                 rawsetfield(L, -2, "__metatable");
             }
         }


### PR DESCRIPTION
[From LuaBridge documentation:](http://vinniefalco.github.io/LuaBridge/Manual.html#s5)

> Metatables have __metatable set to a boolean value. Scripts cannot obtain the metatable from a LuaBridge object. 

According to [Lua docuemtation](https://www.lua.org/pil/13.3.html) the field must be set to prevent tampering with it.
Setting it to nil as it is currently done, effectively does nothing.

I went back to LuaBridge 1.0.0 where is was still correctly a boolean. Since 1.0.2 it changed to nil.

This makes me wonder if there are more security issues with LuaBridge...

